### PR TITLE
added french translation

### DIFF
--- a/src/config/i18n/fr.php
+++ b/src/config/i18n/fr.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+	'view.versions' => 'Versions',
+
+	'error.versions.git.nonzero' => 'Une erreur Git s\'est produite: { message }',
+	'error.versions.git.version' => 'Le plugin Versions nécessite Git 2.5+, vous avez Git { version }',
+	'error.versions.internal' => 'Erreur interne dans le plugin Versions (code d\'erreur { code })',
+	'error.versions.instance.noRepo' => 'Le répertoire de contenu de l\'instance { instance } n\'est pas connectée à un dépôt Git, merci d\'initialiser
+  un nouveau dépôt où connectez le à un arbre de travail (worktree)',
+	'error.versions.instance.noWorktree' => 'Le répertoire de contenu de l\'instance { instance } n\'est pas un arbre de travail (worktree) du répertoire de contenu de ce site actuel, merci de connecter les deux instances en tant qu\'arbre de travail (worktree)',
+	'error.versions.instance.onBranch' => 'Le répertoire de contenu de l\'instance { instance } a toujours une branche \'checked out\', merci d\'exécuter un `git checkout` avec son dernier nom (tag) Git',
+	'error.versions.lockFiles' => 'Une version ne peut pas être créée car des pages ou des fichiers ont des modifications non sauvegardées:',
+	'error.versions.noChanges' => 'Il n\'y a pas de changements à partir duquel créer une version',
+	'error.versions.notPrepared' => 'La version n\'a pas encore été préparée',
+	'error.versions.notFound.instance' => 'L\'instance { name } n\'existe pas',
+	'error.versions.notFound.version' => 'La version { name } n\'existe pas',
+	'error.versions.permission' => 'Vous n\'êtes pas autorisés à faire celà (permission { permission } manquante)',
+	'error.versions.version.inUse' => 'Cette version est actuellement utilisée',
+
+	'versions.button.copyLink' => 'Copier le lien',
+	'versions.button.create' => 'Créer une version',
+	'versions.button.delete' => 'Supprimer',
+	'versions.button.deploy' => 'Déployer',
+	'versions.button.download' => 'Télécharger',
+	'versions.button.export' => 'Exporter',
+
+	'versions.label.changes' => 'Changements',
+	'versions.label.creation' => 'Création',
+	'versions.label.creationData' => '{created} ({creator})',
+	'versions.label.current' => 'actuelle',
+	'versions.label.empty' => 'Pas encore de version',
+	'versions.label.fileSize' => 'Taille du fichier',
+	'versions.label.instances' => 'Instances',
+	'versions.label.label' => 'Label',
+	'versions.label.originInstance' => 'Instance d\'origine',
+	'versions.label.status.+' => 'statut: créé',
+	'versions.label.status.-' => 'statut: supprimé',
+	'versions.label.status.C' => 'statut: copié',
+	'versions.label.status.M' => 'statut: modifié',
+	'versions.label.status.R' => 'statut: renommé',
+	'versions.label.targetInstance' => 'Instance cible',
+	'versions.label.versionName' => 'Nom de la version',
+	'versions.label.versions' => 'Versions',
+
+	'versions.message.delete' => 'Voulez-vous vraiment supprimer cette version?',
+	'versions.message.exporting' => 'Export de la version...',
+
+	'versions.name.autosave' => 'Instantané automatique (snapshot)',
+	'versions.name.local' => 'Local',
+];

--- a/src/config/i18n/fr.php
+++ b/src/config/i18n/fr.php
@@ -6,8 +6,7 @@ return [
 	'error.versions.git.nonzero' => 'Une erreur Git s\'est produite: { message }',
 	'error.versions.git.version' => 'Le plugin Versions nécessite Git 2.5+, vous avez Git { version }',
 	'error.versions.internal' => 'Erreur interne dans le plugin Versions (code d\'erreur { code })',
-	'error.versions.instance.noRepo' => 'Le répertoire de contenu de l\'instance { instance } n\'est pas connectée à un dépôt Git, merci d\'initialiser
-  un nouveau dépôt où connectez le à un arbre de travail (worktree)',
+	'error.versions.instance.noRepo' => 'Le répertoire de contenu de l\'instance { instance } n\'est pas connectée à un dépôt Git, merci d\'initialiser un nouveau dépôt où connectez le à un arbre de travail (worktree)',
 	'error.versions.instance.noWorktree' => 'Le répertoire de contenu de l\'instance { instance } n\'est pas un arbre de travail (worktree) du répertoire de contenu de ce site actuel, merci de connecter les deux instances en tant qu\'arbre de travail (worktree)',
 	'error.versions.instance.onBranch' => 'Le répertoire de contenu de l\'instance { instance } a toujours une branche \'checked out\', merci d\'exécuter un `git checkout` avec son dernier nom (tag) Git',
 	'error.versions.lockFiles' => 'Une version ne peut pas être créée car des pages ou des fichiers ont des modifications non sauvegardées:',

--- a/src/config/translations.php
+++ b/src/config/translations.php
@@ -6,4 +6,5 @@ return [
 
 	// additional translations
 	'de' => require __DIR__ . '/i18n/de.php',
+	'fr' => require __DIR__ . '/i18n/fr.php',
 ];


### PR DESCRIPTION
I made the choice to keep some of the english content in parenthesis as most people are more used to see the english one rather than the french one.

- On line 12 for `versions.instance.onBranch` i kept 'checked out' because i didn't find yet a french way to say it. I may find something when i'll start working with the plugin (in mid september).
- On line 31 for `versions.label.current` i assumed that it is used to talk about a version, so in french it has to be put in the feminine form. I can change it if needed but like my previous point i will necessarily see that mid september.

Apart from that it's my first pull request on a forked project so sorry if i made any mistake.